### PR TITLE
feat: Add field-specific skill assessment feature

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,18 +6,22 @@ import { BreakProvider } from "./src/contexts/BreakContext";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import SplashScreen from "./src/screens/SplashScreen";
 import HomeScreen from "./src/screens/HomeScreen";
+import SelectionScreen from "./src/screens/SelectionScreen";
+import FieldSelectionScreen from "./src/screens/FieldSelectionScreen";
 import InstructionScreen from "./src/screens/InstructionScreen";
 import AssessmentScreen from "./src/screens/AssessmentScreen";
 import ResultScreen from "./src/screens/ResultScreen";
 import HistoryScreen from "./src/screens/HistoryScreen";
 import theme from "./src/styles/theme";
-import { AssessmentHistory } from "./src/types";
+import { AssessmentHistory, FieldType } from "./src/types";
 import { FirstLaunchManager } from "./src/utils/storageManager";
 
 // アプリの画面
 enum AppScreen {
   SPLASH,
   HOME,
+  SELECTION,
+  FIELD_SELECTION,
   INSTRUCTION,
   ASSESSMENT,
   RESULT,
@@ -30,7 +34,8 @@ function AppContent() {
   const [currentScreen, setCurrentScreen] = useState<AppScreen>(AppScreen.SPLASH);
   const [isLoading, setIsLoading] = useState(true);
   const [selectedHistory, setSelectedHistory] = useState<AssessmentHistory | null>(null);
-  const { resetAssessment } = useSkillContext();
+  const [selectedFields, setSelectedFields] = useState<FieldType[]>([]);
+  const { resetAssessment, setAssessmentConfig } = useSkillContext();
 
   // アプリの初期化
   useEffect(() => {
@@ -64,7 +69,7 @@ function AppContent() {
   // ホーム画面から新規評価開始
   const handleStartNew = async () => {
     await resetAssessment(); // 既存のデータをクリア
-    setCurrentScreen(AppScreen.INSTRUCTION);
+    setCurrentScreen(AppScreen.SELECTION);
   };
 
   // ホーム画面から進捗再開
@@ -75,6 +80,34 @@ function AppContent() {
   // ホーム画面から履歴表示
   const handleViewHistory = () => {
     setCurrentScreen(AppScreen.HISTORY);
+  };
+
+  // 選択画面から全スキルチェック選択
+  const handleSelectFullAssessment = async () => {
+    await setAssessmentConfig({ type: 'full' });
+    setCurrentScreen(AppScreen.INSTRUCTION);
+  };
+
+  // 選択画面から分野別チェック選択
+  const handleSelectFieldSpecific = () => {
+    setCurrentScreen(AppScreen.FIELD_SELECTION);
+  };
+
+  // 選択画面から戻る
+  const handleSelectionBack = () => {
+    setCurrentScreen(AppScreen.HOME);
+  };
+
+  // 分野選択画面から評価開始
+  const handleStartFieldAssessment = async (fields: FieldType[]) => {
+    setSelectedFields(fields);
+    await setAssessmentConfig({ type: 'field-specific', selectedFields: fields });
+    setCurrentScreen(AppScreen.INSTRUCTION);
+  };
+
+  // 分野選択画面から戻る
+  const handleFieldSelectionBack = () => {
+    setCurrentScreen(AppScreen.SELECTION);
   };
 
   // 説明画面の完了時
@@ -136,6 +169,21 @@ function AppContent() {
             onStartNew={handleStartNew}
             onResumeProgress={handleResumeProgress}
             onViewHistory={handleViewHistory}
+          />
+        );
+      case AppScreen.SELECTION:
+        return (
+          <SelectionScreen
+            onSelectFullAssessment={handleSelectFullAssessment}
+            onSelectFieldSpecific={handleSelectFieldSpecific}
+            onBack={handleSelectionBack}
+          />
+        );
+      case AppScreen.FIELD_SELECTION:
+        return (
+          <FieldSelectionScreen
+            onStartFieldAssessment={handleStartFieldAssessment}
+            onBack={handleFieldSelectionBack}
           />
         );
       case AppScreen.INSTRUCTION:

--- a/src/components/FieldResultChart.tsx
+++ b/src/components/FieldResultChart.tsx
@@ -1,0 +1,210 @@
+import React from "react";
+import { View, StyleSheet, ScrollView } from "react-native";
+import Typography from "./Typography";
+import theme from "../styles/theme";
+import { FieldSummary } from "../types";
+
+interface FieldResultChartProps {
+  fieldSummaries: FieldSummary[];
+}
+
+const FieldResultChart: React.FC<FieldResultChartProps> = ({ fieldSummaries }) => {
+  const getFieldDisplayName = (field: string) => {
+    switch (field) {
+      case 'インフラエンジニア':
+        return 'インフラエンジニア';
+      case '開発エンジニア（プログラマー）':
+        return 'プログラマー';
+      case '開発エンジニア（SE）':
+        return 'システムエンジニア';
+      case 'マネジメント':
+        return 'マネジメント';
+      default:
+        return field;
+    }
+  };
+
+  const getFieldEmoji = (field: string) => {
+    switch (field) {
+      case 'インフラエンジニア':
+        return '🔧';
+      case '開発エンジニア（プログラマー）':
+        return '💻';
+      case '開発エンジニア（SE）':
+        return '⚙️';
+      case 'マネジメント':
+        return '👥';
+      default:
+        return '📊';
+    }
+  };
+
+  if (fieldSummaries.length === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Typography variant="body1" style={styles.emptyText}>
+          分野別の結果がありません
+        </Typography>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.container} showsVerticalScrollIndicator={false}>
+      {fieldSummaries.map((summary, index) => {
+        const totalAcquired = summary.beginnerCount + summary.intermediateCount + summary.advancedCount;
+        const totalPossible = summary.beginnerTotal + summary.intermediateTotal + summary.advancedTotal;
+        const completionRate = totalPossible > 0 ? (totalAcquired / totalPossible * 100) : 0;
+
+        return (
+          <View key={summary.field} style={styles.fieldContainer}>
+            {/* フィールドヘッダー */}
+            <View style={styles.fieldHeader}>
+              <Typography variant="h6" style={styles.fieldTitle}>
+                {getFieldEmoji(summary.field)} {getFieldDisplayName(summary.field)}
+              </Typography>
+              <Typography variant="body2" style={styles.completionRate}>
+                {Math.round(completionRate)}% ({totalAcquired}/{totalPossible})
+              </Typography>
+            </View>
+
+            {/* 積み上げ棒グラフ */}
+            <View style={styles.chartContainer}>
+              <View style={styles.barContainer}>
+                {/* 初級バー */}
+                <View style={styles.barSection}>
+                  <View style={styles.barBackground}>
+                    <View 
+                      style={[
+                        styles.barFill,
+                        styles.beginnerBar,
+                        { 
+                          width: summary.beginnerTotal > 0 
+                            ? `${(summary.beginnerCount / summary.beginnerTotal) * 100}%` 
+                            : '0%' 
+                        }
+                      ]} 
+                    />
+                  </View>
+                  <Typography variant="caption" style={styles.levelLabel}>
+                    初級 {summary.beginnerCount}/{summary.beginnerTotal}
+                  </Typography>
+                </View>
+
+                {/* 中級バー */}
+                <View style={styles.barSection}>
+                  <View style={styles.barBackground}>
+                    <View 
+                      style={[
+                        styles.barFill,
+                        styles.intermediateBar,
+                        { 
+                          width: summary.intermediateTotal > 0 
+                            ? `${(summary.intermediateCount / summary.intermediateTotal) * 100}%` 
+                            : '0%' 
+                        }
+                      ]} 
+                    />
+                  </View>
+                  <Typography variant="caption" style={styles.levelLabel}>
+                    中級 {summary.intermediateCount}/{summary.intermediateTotal}
+                  </Typography>
+                </View>
+
+                {/* 上級バー */}
+                <View style={styles.barSection}>
+                  <View style={styles.barBackground}>
+                    <View 
+                      style={[
+                        styles.barFill,
+                        styles.advancedBar,
+                        { 
+                          width: summary.advancedTotal > 0 
+                            ? `${(summary.advancedCount / summary.advancedTotal) * 100}%` 
+                            : '0%' 
+                        }
+                      ]} 
+                    />
+                  </View>
+                  <Typography variant="caption" style={styles.levelLabel}>
+                    上級 {summary.advancedCount}/{summary.advancedTotal}
+                  </Typography>
+                </View>
+              </View>
+            </View>
+          </View>
+        );
+      })}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: theme.spacing.xl,
+  },
+  emptyText: {
+    color: theme.colors.gray[600],
+    textAlign: "center",
+  },
+  fieldContainer: {
+    marginBottom: theme.spacing.lg,
+    paddingHorizontal: theme.spacing.sm,
+  },
+  fieldHeader: {
+    marginBottom: theme.spacing.md,
+    alignItems: "center",
+  },
+  fieldTitle: {
+    marginBottom: theme.spacing.xs,
+    textAlign: "center",
+  },
+  completionRate: {
+    color: theme.colors.primary.main,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  chartContainer: {
+    paddingHorizontal: theme.spacing.sm,
+  },
+  barContainer: {
+    gap: theme.spacing.sm,
+  },
+  barSection: {
+    marginBottom: theme.spacing.sm,
+  },
+  barBackground: {
+    height: 24,
+    backgroundColor: theme.colors.gray[200],
+    borderRadius: 12,
+    overflow: "hidden",
+    marginBottom: theme.spacing.xs,
+  },
+  barFill: {
+    height: "100%",
+    borderRadius: 12,
+    minWidth: 4,
+  },
+  beginnerBar: {
+    backgroundColor: theme.colors.accent.success,
+  },
+  intermediateBar: {
+    backgroundColor: theme.colors.accent.warning,
+  },
+  advancedBar: {
+    backgroundColor: theme.colors.accent.error,
+  },
+  levelLabel: {
+    color: theme.colors.gray[700],
+    fontSize: 12,
+    textAlign: "center",
+  },
+});
+
+export default FieldResultChart;

--- a/src/screens/FieldSelectionScreen.tsx
+++ b/src/screens/FieldSelectionScreen.tsx
@@ -1,0 +1,251 @@
+import React, { useState } from "react";
+import { View, StyleSheet, ScrollView } from "react-native";
+import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
+import Typography from "../components/Typography";
+import Button from "../components/Button";
+import Card from "../components/Card";
+import theme from "../styles/theme";
+import { FieldType } from "../types";
+
+interface FieldSelectionScreenProps {
+  onStartFieldAssessment: (selectedFields: FieldType[]) => void;
+  onBack: () => void;
+}
+
+const FieldSelectionScreen: React.FC<FieldSelectionScreenProps> = ({
+  onStartFieldAssessment,
+  onBack
+}) => {
+  const insets = useSafeAreaInsets();
+  const [selectedFields, setSelectedFields] = useState<FieldType[]>([]);
+
+  const fieldOptions = [
+    {
+      key: 'インフラエンジニア' as FieldType,
+      title: '🔧 インフラエンジニア',
+      description: 'サーバー、クラウド、ネットワークのスキル',
+      emoji: '🔧'
+    },
+    {
+      key: '開発エンジニア（プログラマー）' as FieldType,
+      title: '💻 プログラマー',
+      description: 'プログラミング、フロントエンド、バックエンドのスキル',
+      emoji: '💻'
+    },
+    {
+      key: '開発エンジニア（SE）' as FieldType,
+      title: '⚙️ システムエンジニア',
+      description: '設計、データベース、開発プロセス、セキュリティのスキル',
+      emoji: '⚙️'
+    },
+    {
+      key: 'マネジメント' as FieldType,
+      title: '👥 マネジメント',
+      description: 'チーム管理、プロジェクト管理、組織運営のスキル',
+      emoji: '👥'
+    }
+  ];
+
+  const toggleField = (field: FieldType) => {
+    if (selectedFields.includes(field)) {
+      setSelectedFields(selectedFields.filter(f => f !== field));
+    } else {
+      setSelectedFields([...selectedFields, field]);
+    }
+  };
+
+  const handleStart = () => {
+    if (selectedFields.length > 0) {
+      onStartFieldAssessment(selectedFields);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={[styles.content, { paddingTop: insets.top + theme.spacing.md }]}>
+        {/* ヘッダー */}
+        <View style={styles.header}>
+          <Typography variant="h3" align="center" style={styles.title}>
+            分野の選択
+          </Typography>
+          <Typography variant="body1" align="center" style={styles.subtitle}>
+            評価したい分野を選択してください（複数選択可）
+          </Typography>
+          <View style={styles.warningContainer}>
+            <Typography variant="body2" style={styles.warningText}>
+              ⚠️ 分野別評価の結果は履歴に保存されません
+            </Typography>
+          </View>
+        </View>
+
+        {/* 分野選択 */}
+        <ScrollView style={styles.fieldsContainer} showsVerticalScrollIndicator={false}>
+          {fieldOptions.map((field) => {
+            const isSelected = selectedFields.includes(field.key);
+            return (
+              <Card
+                key={field.key}
+                variant={isSelected ? "elevated" : "outlined"}
+                style={[
+                  styles.fieldCard,
+                  isSelected && styles.selectedFieldCard
+                ]}
+                onPress={() => toggleField(field.key)}
+              >
+                <View style={styles.fieldCardContent}>
+                  <View style={styles.fieldInfo}>
+                    <Typography variant="h6" style={styles.fieldTitle}>
+                      {field.title}
+                    </Typography>
+                    <Typography variant="body2" style={styles.fieldDescription}>
+                      {field.description}
+                    </Typography>
+                  </View>
+                  <View style={styles.checkboxContainer}>
+                    <View style={[
+                      styles.checkbox,
+                      isSelected && styles.checkboxSelected
+                    ]}>
+                      {isSelected && (
+                        <Typography variant="caption" style={styles.checkmark}>
+                          ✓
+                        </Typography>
+                      )}
+                    </View>
+                  </View>
+                </View>
+              </Card>
+            );
+          })}
+        </ScrollView>
+
+        {/* ボタン */}
+        <View style={styles.buttonContainer}>
+          <Typography variant="caption" style={styles.selectedCount}>
+            {selectedFields.length > 0 ? `${selectedFields.length}つの分野を選択中` : '分野を選択してください'}
+          </Typography>
+          <View style={styles.buttonRow}>
+            <Button
+              title="戻る"
+              onPress={onBack}
+              variant="outline"
+              style={styles.backButton}
+            />
+            <Button
+              title="評価開始"
+              onPress={handleStart}
+              variant="primary"
+              style={styles.startButton}
+              disabled={selectedFields.length === 0}
+            />
+          </View>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.common.background,
+  },
+  content: {
+    flex: 1,
+    padding: theme.spacing.lg,
+  },
+  header: {
+    marginBottom: theme.spacing.lg,
+    alignItems: "center",
+  },
+  title: {
+    marginBottom: theme.spacing.sm,
+    color: theme.colors.primary.main,
+  },
+  subtitle: {
+    color: theme.colors.gray[600],
+    textAlign: "center",
+    lineHeight: 24,
+    marginBottom: theme.spacing.md,
+  },
+  warningContainer: {
+    backgroundColor: theme.colors.accent.warning + '20',
+    padding: theme.spacing.sm,
+    borderRadius: theme.borderRadius.md,
+    borderWidth: 1,
+    borderColor: theme.colors.accent.warning + '40',
+  },
+  warningText: {
+    color: theme.colors.accent.warning,
+    textAlign: "center",
+    fontWeight: "600",
+  },
+  fieldsContainer: {
+    flex: 1,
+  },
+  fieldCard: {
+    marginBottom: theme.spacing.md,
+    padding: theme.spacing.md,
+  },
+  selectedFieldCard: {
+    borderColor: theme.colors.primary.main,
+    borderWidth: 2,
+    backgroundColor: theme.colors.primary.main + '10',
+  },
+  fieldCardContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  fieldInfo: {
+    flex: 1,
+  },
+  fieldTitle: {
+    marginBottom: theme.spacing.xs,
+  },
+  fieldDescription: {
+    color: theme.colors.gray[600],
+    lineHeight: 18,
+  },
+  checkboxContainer: {
+    marginLeft: theme.spacing.md,
+  },
+  checkbox: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    borderWidth: 2,
+    borderColor: theme.colors.gray[400],
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  checkboxSelected: {
+    backgroundColor: theme.colors.primary.main,
+    borderColor: theme.colors.primary.main,
+  },
+  checkmark: {
+    color: "white",
+    fontWeight: "bold",
+    fontSize: 14,
+  },
+  buttonContainer: {
+    alignItems: "center",
+    marginTop: theme.spacing.lg,
+  },
+  selectedCount: {
+    color: theme.colors.gray[600],
+    marginBottom: theme.spacing.md,
+  },
+  buttonRow: {
+    flexDirection: "row",
+    gap: theme.spacing.md,
+  },
+  backButton: {
+    minWidth: 100,
+  },
+  startButton: {
+    minWidth: 120,
+  },
+});
+
+export default FieldSelectionScreen;

--- a/src/screens/SelectionScreen.tsx
+++ b/src/screens/SelectionScreen.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
+import Typography from "../components/Typography";
+import Button from "../components/Button";
+import Card from "../components/Card";
+import theme from "../styles/theme";
+
+interface SelectionScreenProps {
+  onSelectFullAssessment: () => void;
+  onSelectFieldSpecific: () => void;
+  onBack: () => void;
+}
+
+const SelectionScreen: React.FC<SelectionScreenProps> = ({
+  onSelectFullAssessment,
+  onSelectFieldSpecific,
+  onBack
+}) => {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={[styles.content, { paddingTop: insets.top + theme.spacing.md }]}>
+        {/* ヘッダー */}
+        <View style={styles.header}>
+          <Typography variant="h3" align="center" style={styles.title}>
+            評価タイプの選択
+          </Typography>
+          <Typography variant="body1" align="center" style={styles.subtitle}>
+            全体評価または分野別評価を選択してください
+          </Typography>
+        </View>
+
+        {/* 選択肢 */}
+        <View style={styles.optionsContainer}>
+          {/* 全スキルチェック */}
+          <Card variant="elevated" style={styles.optionCard}>
+            <Typography variant="h5" style={styles.optionTitle}>
+              🚀 全スキルチェック
+            </Typography>
+            <Typography variant="body2" style={styles.optionDescription}>
+              128項目のすべてのスキルを評価します（約15-20分）
+            </Typography>
+            <Typography variant="caption" style={styles.optionNote}>
+              • 結果は履歴に保存されます
+              • 総合的なスキル分析が可能
+              • レーダーチャートで表示
+            </Typography>
+            <Button
+              title="全スキルチェック"
+              onPress={onSelectFullAssessment}
+              variant="primary"
+              style={styles.optionButton}
+            />
+          </Card>
+
+          {/* 分野ごとのチェック */}
+          <Card variant="elevated" style={styles.optionCard}>
+            <Typography variant="h5" style={styles.optionTitle}>
+              📊 分野ごとのチェック
+            </Typography>
+            <Typography variant="body2" style={styles.optionDescription}>
+              特定の分野のみを選択して評価します（約5-10分）
+            </Typography>
+            <Typography variant="caption" style={styles.optionNote}>
+              • インフラエンジニア
+              • プログラマー  
+              • システムエンジニア
+              • マネジメント
+            </Typography>
+            <Typography variant="caption" style={[styles.optionNote, styles.warningNote]}>
+              ⚠️ 分野別評価の結果は履歴に保存されません
+            </Typography>
+            <Button
+              title="分野を選択"
+              onPress={onSelectFieldSpecific}
+              variant="secondary"
+              style={styles.optionButton}
+            />
+          </Card>
+        </View>
+
+        {/* 戻るボタン */}
+        <View style={styles.backButtonContainer}>
+          <Button
+            title="戻る"
+            onPress={onBack}
+            variant="outline"
+            style={styles.backButton}
+          />
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.common.background,
+  },
+  content: {
+    flex: 1,
+    padding: theme.spacing.lg,
+  },
+  header: {
+    marginBottom: theme.spacing.xl,
+    alignItems: "center",
+  },
+  title: {
+    marginBottom: theme.spacing.sm,
+    color: theme.colors.primary.main,
+  },
+  subtitle: {
+    color: theme.colors.gray[600],
+    textAlign: "center",
+    lineHeight: 24,
+  },
+  optionsContainer: {
+    flex: 1,
+    gap: theme.spacing.lg,
+  },
+  optionCard: {
+    padding: theme.spacing.lg,
+    alignItems: "center",
+  },
+  optionTitle: {
+    marginBottom: theme.spacing.sm,
+    textAlign: "center",
+  },
+  optionDescription: {
+    marginBottom: theme.spacing.md,
+    color: theme.colors.gray[700],
+    textAlign: "center",
+    lineHeight: 20,
+  },
+  optionNote: {
+    color: theme.colors.gray[600],
+    textAlign: "center",
+    lineHeight: 18,
+    marginBottom: theme.spacing.sm,
+  },
+  warningNote: {
+    color: theme.colors.accent.warning,
+    fontWeight: "600",
+  },
+  optionButton: {
+    minWidth: 150,
+    marginTop: theme.spacing.sm,
+  },
+  backButtonContainer: {
+    alignItems: "center",
+    marginTop: theme.spacing.lg,
+  },
+  backButton: {
+    minWidth: 120,
+  },
+});
+
+export default SelectionScreen;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,3 +84,26 @@ export interface UserProfile {
   assessmentHistory: AssessmentHistory[];
   savedProgress?: SavedProgress;
 }
+
+// 評価タイプの定義
+export type AssessmentType = 'full' | 'field-specific';
+
+// 分野の定義
+export type FieldType = 'インフラエンジニア' | '開発エンジニア（プログラマー）' | '開発エンジニア（SE）' | 'マネジメント';
+
+// 評価設定の型定義
+export interface AssessmentConfig {
+  type: AssessmentType;
+  selectedFields?: FieldType[];
+}
+
+// 分野別集計結果の型定義
+export interface FieldSummary {
+  field: FieldType;
+  beginnerCount: number;
+  beginnerTotal: number;
+  intermediateCount: number;
+  intermediateTotal: number;
+  advancedCount: number;
+  advancedTotal: number;
+}


### PR DESCRIPTION
## Summary
- Add selection screen for choosing between full and field-specific assessments
- Implement field selection for Infrastructure, Programmer, SE, Management domains
- Add field-specific assessment logic that filters questions by selected fields
- Prevent field-specific results from being saved to history
- Implement stacked bar chart visualization for field-specific results
- Add user notifications that field-specific results aren't saved

## Test plan
- [ ] Test full skill assessment flow (should work as before)
- [ ] Test field-specific assessment selection and flow
- [ ] Verify field-specific results don't save to history
- [ ] Test stacked bar chart visualization
- [ ] Verify warning messages appear correctly

🤖 Generated with [Claude Code](https://claude.ai/code)